### PR TITLE
NCheferizer: Add skip rules.

### DIFF
--- a/NCheferizer.sln
+++ b/NCheferizer.sln
@@ -1,9 +1,11 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio 15
-VisualStudioVersion = 15.0.26228.9
+VisualStudioVersion = 15.0.26430.12
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "NCheferizer", "src\NCheferizer\NCheferizer.csproj", "{76B500E4-6ABC-40C7-B8E5-62E0B2664291}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "NCheferizer.Tests", "src\NCheferizer.Tests\NCheferizer.Tests.csproj", "{2A7DF3CA-435F-46A5-A309-0EBA42E1AD90}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -15,6 +17,10 @@ Global
 		{76B500E4-6ABC-40C7-B8E5-62E0B2664291}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{76B500E4-6ABC-40C7-B8E5-62E0B2664291}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{76B500E4-6ABC-40C7-B8E5-62E0B2664291}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2A7DF3CA-435F-46A5-A309-0EBA42E1AD90}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2A7DF3CA-435F-46A5-A309-0EBA42E1AD90}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2A7DF3CA-435F-46A5-A309-0EBA42E1AD90}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2A7DF3CA-435F-46A5-A309-0EBA42E1AD90}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/src/NCheferizer.Tests/EncheferizerTests.cs
+++ b/src/NCheferizer.Tests/EncheferizerTests.cs
@@ -1,0 +1,24 @@
+using System;
+
+using Xunit;
+
+namespace NCheferizer.Tests
+{
+    public class EncheferizerTests
+    {
+        [Theory]
+        [InlineData("Hello, world! #blessed", "Hellu, vurld! #blessed")]
+        [InlineData("What are you looking at, @horse_js?", "Vhet ere-a yuoo luukeeng et, @horse_js?")]
+        public void Skip_rules_skip_words(string input, string expected)
+        {
+            var skipRules = new Func<string, bool>[] {
+                word => word[0] == '#',
+                word => word[0] == '@',
+            };
+
+            var output = input.Encheferize(false, skipRules);
+
+            Assert.Equal(expected, output);
+        }
+    }
+}

--- a/src/NCheferizer.Tests/NCheferizer.Tests.csproj
+++ b/src/NCheferizer.Tests/NCheferizer.Tests.csproj
@@ -1,0 +1,17 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>    
+    <TargetFramework>netcoreapp1.1</TargetFramework>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\NCheferizer\NCheferizer.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/NCheferizer/Encheferizer.cs
+++ b/src/NCheferizer/Encheferizer.cs
@@ -3,12 +3,14 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 
+using JetBrains.Annotations;
+
 namespace NCheferizer
 {
     delegate RuleResult Rule(string subject, Position pos, Context context);
 
-    // ReSharper disable once ClassNeverInstantiated.Global
-    class Encheferizer
+    [PublicAPI]
+    public class Encheferizer
     {
         // ReSharper disable once InconsistentNaming
         static readonly Lazy<Encheferizer> instance = new Lazy<Encheferizer>();
@@ -187,18 +189,12 @@ namespace NCheferizer
 
             DefineRule(
                 "V becomes F",
-                (subject, position, context) => {
-                    if (char.ToLower(subject[0]) == 'v')
-                        return new RuleResult(ChangeCase('f', subject[0]), 1);
-                    return null;
-                }
+                (subject, position, context) => char.ToLower(subject[0]) == 'v' ? new RuleResult(ChangeCase('f', subject[0]), 1) : null
             );
 
             DefineRule(
                 "W becomes V",
-                (subject, position, context) => {
-                    return char.ToLower(subject[0]) == 'w' ? new RuleResult(ChangeCase('v', subject[0]), 1) : null;
-                }
+                (subject, position, context) => char.ToLower(subject[0]) == 'w' ? new RuleResult(ChangeCase('v', subject[0]), 1) : null
             );
 
             DefineRule(
@@ -218,10 +214,11 @@ namespace NCheferizer
         /// </summary>
         /// <param name="input">The input text.</param>
         /// <param name="shouldBork">Should I bork?</param>
+        /// <param name="skipRules">An array of predicates to determine if words should be skipped.</param>
         /// <returns>An encheferized string.</returns>
         /// <remarks>This method is thread-safe.</remarks>
-        public string Encheferize(string input, bool shouldBork = true)
-            => string.Join(" ", input.Split(' ').Select(w => EncheferizeWord(w, shouldBork)));
+        public string Encheferize(string input, bool shouldBork = true, params Func<string, bool>[] skipRules)
+            => string.Join(" ", input.Split(' ').Select(w => skipRules.Any(sr => sr(w)) ? w : EncheferizeWord(w, shouldBork)));
 
         string EncheferizeWord(string word, bool shouldBork)
         {

--- a/src/NCheferizer/NCheferizer.csproj
+++ b/src/NCheferizer/NCheferizer.csproj
@@ -27,6 +27,7 @@
 
   <ItemGroup>
     <PackageReference Include="GitInfo" Version="1.1.63" PrivateAssets="All" />
+    <PackageReference Include="JetBrains.Annotations" Version="10.4.0" PrivateAssets="All" />
   </ItemGroup>
 
   <Target Name="SetVersion" DependsOnTargets="GitInfo" BeforeTargets="CoreCompile;GetAssemblyVersion;GenerateNuspec;_GenerateRestoreProjectSpec;EnsureWixToolsetInstalled" Condition="$(GitInfoImported) == 'True'">

--- a/src/NCheferizer/StringExtensions.cs
+++ b/src/NCheferizer/StringExtensions.cs
@@ -1,7 +1,10 @@
-﻿// ReSharper disable UnusedMember.Global
+﻿using System;
+
+using JetBrains.Annotations;
 
 namespace NCheferizer
 {
+    [PublicAPI]
     public static class StringExtensions
     {
         /// <summary>
@@ -13,5 +16,16 @@ namespace NCheferizer
         /// <remarks>This method is thread-safe.</remarks>
         public static string Encheferize(this string input, bool shouldBork)
             => Encheferizer.Instance.Encheferize(input, shouldBork);
+
+        /// <summary>
+        /// Encheferize the input string.
+        /// </summary>
+        /// <param name="input">The string to encheferize.</param>
+        /// <param name="shouldBork">Should I bork?</param>
+        /// <param name="skipRules">An array of rules by which to skip words.</param>
+        /// <returns>The encheferized string.</returns>
+        /// <remarks>This method is thread-safe.</remarks>
+        public static string Encheferize(this string input, bool shouldBork, params Func<string, bool>[] skipRules)
+            => Encheferizer.Instance.Encheferize(input, shouldBork, skipRules);
     }
 }


### PR DESCRIPTION
Skip rules allow callers to register predicates to check words against to determine if they should be cheferized or if they should be skipped.